### PR TITLE
add  `NEXTAUTH_URL` for .env.development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+NEXTAUTH_URL=http://localhost:3000


### PR DESCRIPTION
Perhaps a common pitfall? (i was stuck with this for several hours 