### PR TITLE
Add drizzle-kit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ npx create-next-app nextjs-typescript-starter --example "https://github.com/verc
 
 ## Getting Started
 
-First, run the development server:
+Copy .env.example to .env and add your postgresql settings, along with a randomly created AUTH_SECRET value.
+Then, apply the drizzle schema to your database:
+
+```
+drizzle-kit push
+```
+
+Finally, run the development server:
 
 ```bash
 pnpm dev

--- a/app/db.ts
+++ b/app/db.ts
@@ -1,20 +1,15 @@
 import { drizzle } from 'drizzle-orm/postgres-js';
-import { pgTable, serial, varchar } from 'drizzle-orm/pg-core';
 import { eq } from 'drizzle-orm';
 import postgres from 'postgres';
 import { genSaltSync, hashSync } from 'bcrypt-ts';
+import { users } from './schema';
 
 // Optionally, if not using email/pass login, you can
 // use the Drizzle adapter for Auth.js / NextAuth
 // https://authjs.dev/reference/adapter/drizzle
-let client = postgres(`${process.env.POSTGRES_URL!}?sslmode=require`);
+let client = postgres(`${process.env.POSTGRES_URL!}`);
 let db = drizzle(client);
 
-let users = pgTable('User', {
-  id: serial('id').primaryKey(),
-  email: varchar('email', { length: 64 }),
-  password: varchar('password', { length: 64 }),
-});
 
 export async function getUser(email: string) {
   return await db.select().from(users).where(eq(users.email, email));

--- a/app/schema.ts
+++ b/app/schema.ts
@@ -1,0 +1,7 @@
+import { pgTable, serial, varchar } from 'drizzle-orm/pg-core';
+
+export const users = pgTable('User', {
+  id: serial('id').primaryKey(),
+  email: varchar('email', { length: 64 }),
+  password: varchar('password', { length: 64 }),
+});

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+    schema: './app/schema.ts',
+    out: './drizzle',
+    dialect: 'postgresql',
+    dbCredentials: {
+        url: process.env.POSTGRES_URL!
+    }
+  });

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "dev": "next dev --turbo",
     "build": "next build",
+    "generate": "drizzle-kit generate:pg --out drizzle --schema app/db/schema.ts",
     "start": "next start",
     "lint": "next lint"
   },
@@ -21,6 +22,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.16",
+    "drizzle-kit": "^0.21.4",
     "eslint": "8.56.0",
     "eslint-config-next": "^14.0.4",
     "postcss": "^8.4.32",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This PR splits out the schema into a schema file, adds a dev dependency on drizzle-kit, and adds a configuration file to allow drizzle-kit to apply the schema changes. The README is also adjusted accordingly.

I removed the sslmode=require that was in the client connection string as its the default I believe and also breaks connections if you provided any options yourself.

It all works correctly in my environment but I haven't tried it against other versions or bumped any dependencies.